### PR TITLE
Add custom recipe for Insecurity Insight

### DIFF
--- a/recipes/insecurity-insight/recipe.json
+++ b/recipes/insecurity-insight/recipe.json
@@ -23,8 +23,6 @@
         ],
         "aggregateColumns": [
           "#adm1+name",
-          "#date+month",
-          "#event+type",
           "#event+context",
           "#impact+type"
         ],
@@ -44,9 +42,7 @@
         ],
         "aggregateColumns": [
           "#adm1+name",
-          "#date+month"
-        ],
-        "valueColumns": [
+          "#date+month",
           "#event+type",
           "#event+context",
           "#group"
@@ -54,17 +50,12 @@
       }
     },
     {
-      "name": "Timeseries: sum affected people or events grouped by administrative units",
+      "name": "Key Figures: Sum items",
       "description": "",
-      "type": "timeseries",
+      "type": "key figure",
       "ingredients": {
         "aggregateFunctions": [
-          "sum",
-          "count"
-        ],
-        "aggregateColumns": [
-          "#date",
-          "#adm1"
+          "sum"
         ],
         "valueColumns": [
           "#affected",
@@ -73,19 +64,12 @@
       }
     },
     {
-      "name": "Key Figures: Sum/count items",
+      "name": "Key Figures: Count items",
       "description": "",
       "type": "key figure",
       "ingredients": {
         "aggregateFunctions": [
-          "sum",
           "count"
-        ],
-        "valueColumns": [
-          "#affected",
-          "#indicator+num",
-          "#event+context",
-          "#event+type"
         ]
       }
     }

--- a/recipes/insecurity-insight/recipe.json
+++ b/recipes/insecurity-insight/recipe.json
@@ -4,7 +4,6 @@
   "type": "cookbook",
   "default": false,
   "columns": [
-    "#country",
     "#adm1",
     "#indicator",
     "#event",
@@ -23,7 +22,6 @@
           "sum"
         ],
         "aggregateColumns": [
-          "#country+name",
           "#adm1+name",
           "#date+month",
           "#event+type",
@@ -45,7 +43,6 @@
           "count"
         ],
         "aggregateColumns": [
-          "#country+name",
           "#adm1+name",
           "#date+month"
         ],
@@ -67,7 +64,6 @@
         ],
         "aggregateColumns": [
           "#date",
-          "#country",
           "#adm1"
         ],
         "valueColumns": [

--- a/recipes/insecurity-insight/recipe.json
+++ b/recipes/insecurity-insight/recipe.json
@@ -1,0 +1,97 @@
+{
+  "name": "insecurity-insight",
+  "title": "Insecurity Insight",
+  "type": "cookbook",
+  "default": false,
+  "columns": [
+    "#country",
+    "#adm1",
+    "#indicator",
+    "#event",
+    "#date",
+    "#affected",
+    "#impact",
+    "#group"
+  ],
+  "recipes": [
+    {
+      "name": "Chart numbers of affected people or events against different aggregators.",
+      "description": "",
+      "type": "chart",
+      "ingredients": {
+        "aggregateFunctions": [
+          "sum"
+        ],
+        "aggregateColumns": [
+          "#country+name",
+          "#adm1+name",
+          "#date+month",
+          "#event+type",
+          "#event+context",
+          "#impact+type"
+        ],
+        "valueColumns": [
+          "#affected",
+          "#indicator+num"
+        ]
+      }
+    },
+    {
+      "name": "Count contexts, event types, or groups against different aggregators",
+      "description": "",
+      "type": "chart",
+      "ingredients": {
+        "aggregateFunctions": [
+          "count"
+        ],
+        "aggregateColumns": [
+          "#country+name",
+          "#adm1+name",
+          "#date+month"
+        ],
+        "valueColumns": [
+          "#event+type",
+          "#event+context",
+          "#group"
+        ]
+      }
+    },
+    {
+      "name": "Timeseries: sum affected people or events grouped by administrative units",
+      "description": "",
+      "type": "timeseries",
+      "ingredients": {
+        "aggregateFunctions": [
+          "sum",
+          "count"
+        ],
+        "aggregateColumns": [
+          "#date",
+          "#country",
+          "#adm1"
+        ],
+        "valueColumns": [
+          "#affected",
+          "#indicator+num"
+        ]
+      }
+    },
+    {
+      "name": "Key Figures: Sum/count items",
+      "description": "",
+      "type": "key figure",
+      "ingredients": {
+        "aggregateFunctions": [
+          "sum",
+          "count"
+        ],
+        "valueColumns": [
+          "#affected",
+          "#indicator+num",
+          "#event+context",
+          "#event+type"
+        ]
+      }
+    }
+  ]
+}

--- a/recipes/insecurity-insight/recipe.json
+++ b/recipes/insecurity-insight/recipe.json
@@ -4,72 +4,100 @@
   "type": "cookbook",
   "default": false,
   "columns": [
-    "#adm1",
-    "#indicator",
-    "#event",
     "#date",
-    "#affected",
-    "#impact",
-    "#group"
+    "#event",
+    "#affected"
   ],
   "recipes": [
     {
-      "name": "Chart numbers of affected people or events against different aggregators.",
-      "description": "",
-      "type": "chart",
+      "name": "Key figure: events (all types)",
+      "description": "Total number of events, including those related to the global COVID-19 pandemic and to civil conflict.",
+      "type": "key figure",
       "ingredients": {
         "aggregateFunctions": [
-          "sum"
-        ],
-        "aggregateColumns": [
-          "#adm1+name",
-          "#event+context",
-          "#impact+type"
-        ],
-        "valueColumns": [
-          "#affected",
-          "#indicator+num"
+          "count"
         ]
       }
     },
     {
-      "name": "Count contexts, event types, or groups against different aggregators",
-      "description": "",
+      "name": "Key figure: events related to COVID-19",
+      "description": "Total number of events related to the global COVID-19 pandemic.",
+      "type": "key figure",
+      "ingredients": {
+        "aggregateFunctions": [
+          "count"
+        ],
+        "filtersWith": [
+          {
+            "#event+type+covid19": "COVIDEvent"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Key figure: events related to conflict",
+      "description": "Total number of events related to civil conflict.",
+      "type": "key figure",
+      "ingredients": {
+        "aggregateFunctions": [
+          "count"
+        ],
+        "filtersWith": [
+          {
+            "#event+type+conflict": "ConflictEvent"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Chart: events (all causes)",
+      "description": "Total number of events related to both the global COVID-19 pandemic and civil conflict.",
       "type": "chart",
       "ingredients": {
         "aggregateFunctions": [
           "count"
         ],
         "aggregateColumns": [
-          "#adm1+name",
-          "#date+month",
-          "#event+type",
-          "#event+context",
-          "#group"
+          "#date",
+          "#country"
         ]
       }
     },
     {
-      "name": "Key Figures: Sum items",
-      "description": "",
-      "type": "key figure",
-      "ingredients": {
-        "aggregateFunctions": [
-          "sum"
-        ],
-        "valueColumns": [
-          "#affected",
-          "#indicator+num"
-        ]
-      }
-    },
-    {
-      "name": "Key Figures: Count items",
-      "description": "",
-      "type": "key figure",
+      "name": "Chart: events related to COVID-19",
+      "description": "Total number of events related to the global COVID-19 pandemic.",
+      "type": "chart",
       "ingredients": {
         "aggregateFunctions": [
           "count"
+        ],
+        "aggregateColumns": [
+          "#date",
+          "#country"
+        ],
+        "filtersWith": [
+          {
+            "#event+type+covid19": "COVIDEvent"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Chart: events related to conflict",
+      "description": "Total number of events related to civil conflict.",
+      "type": "chart",
+      "ingredients": {
+        "aggregateFunctions": [
+          "count"
+        ],
+        "aggregateColumns": [
+          "#date",
+          "#country"
+        ],
+        "filtersWith": [
+          {
+            "#event+type+conflict": "ConflictEvent"
+          }
         ]
       }
     }


### PR DESCRIPTION
Added new custom Quick Charts recipe for Insecurity Insight (includes special filters to distinguish events related to COVID-19 vs civil conflict). Quick Charts approved by data partner. No changes to existing recipes.