### PR TITLE
Update recipe.json to add #indicator as an aggregator as well as a value

### DIFF
--- a/recipes/hdx/recipe.json
+++ b/recipes/hdx/recipe.json
@@ -47,7 +47,8 @@
           "#region",
           "#loc",
           "#org",
-          "#sector"
+          "#sector",
+          "#indicator"
         ],
         "valueColumns": [
           "#affected",

--- a/recipes/iati/recipe.json
+++ b/recipes/iati/recipe.json
@@ -5,7 +5,8 @@
   "columns": [
     "#activity+id",
     "#sector",
-    "#org+reporting+name"
+    "#org+reporting+name",
+    "#loc+name"
   ],
   "recipes": [
     {
@@ -50,23 +51,6 @@
         ],
         "aggregateColumns": [
           "#sector"
-        ],
-        "valueColumns": [
-          "#activity+id"
-        ]
-      }
-    },
-    {
-      "title": "Most-active subsectors",
-      "name": "Most-active subsectors",
-      "description": "",
-      "type": "chart",
-      "ingredients": {
-        "aggregateFunctions": [
-          "distinct-count"
-        ],
-        "aggregateColumns": [
-          "#subsector"
         ],
         "valueColumns": [
           "#activity+id"

--- a/recipes/iati/recipe.json
+++ b/recipes/iati/recipe.json
@@ -66,7 +66,7 @@
           "distinct-count"
         ],
         "aggregateColumns": [
-          "#subsector+name"
+          "#subsector"
         ],
         "valueColumns": [
           "#activity+id"

--- a/recipes/iati/recipe.json
+++ b/recipes/iati/recipe.json
@@ -15,7 +15,7 @@
       "type": "key figure",
       "ingredients": {
         "aggregateFunctions": [
-          "count"
+          "distinct-count"
         ],
         "valueColumns": [
           "#activity+id"

--- a/recipes/iati/recipe.json
+++ b/recipes/iati/recipe.json
@@ -38,6 +38,11 @@
         ],
         "valueColumns":[
           "#activity+id"
+        ],
+        "filtersWithout": [
+          {
+            "#org+reporting+name": ""
+          }           
         ]
       }
     },
@@ -55,6 +60,11 @@
         ],
         "valueColumns": [
           "#activity+id"
+        ],
+        "filtersWithout": [
+          {
+            "#sector": ""
+          }           
         ]
       }
     },
@@ -72,6 +82,11 @@
         ],
         "valueColumns": [
           "#activity+id"
+        ],
+        "filtersWithout": [
+          {
+            "#subsector": ""
+          }           
         ]
       }
     },

--- a/recipes/iati/recipe.json
+++ b/recipes/iati/recipe.json
@@ -91,7 +91,9 @@
           "#activity+id"
         ],
         "filtersWithout": [
-          "#loc+name": ""
+          {
+            "#loc+name": ""
+          }           
         ]
       }
     }

--- a/recipes/iati/recipe.json
+++ b/recipes/iati/recipe.json
@@ -5,6 +5,7 @@
   "columns": [
     "#activity+id",
     "#sector",
+    "#subsector",
     "#org+reporting+name",
     "#loc+name"
   ],
@@ -51,6 +52,23 @@
         ],
         "aggregateColumns": [
           "#sector"
+        ],
+        "valueColumns": [
+          "#activity+id"
+        ]
+      }
+    },
+    {
+      "title": "Most-active subsectors",
+      "name": "Most-active subsectors",
+      "description": "",
+      "type": "chart",
+      "ingredients": {
+        "aggregateFunctions": [
+          "distinct-count"
+        ],
+        "aggregateColumns": [
+          "#subsector"
         ],
         "valueColumns": [
           "#activity+id"

--- a/recipes/iati/recipe.json
+++ b/recipes/iati/recipe.json
@@ -89,6 +89,9 @@
         ],
         "valueColumns": [
           "#activity+id"
+        ],
+        "filtersWithout": [
+          "#loc+name": ""
         ]
       }
     }

--- a/recipes/iati/recipe.json
+++ b/recipes/iati/recipe.json
@@ -49,7 +49,7 @@
           "distinct-count"
         ],
         "aggregateColumns": [
-          "#sector"
+          "#sector+name"
         ],
         "valueColumns": [
           "#activity+id"

--- a/recipes/iati/recipe.json
+++ b/recipes/iati/recipe.json
@@ -55,6 +55,40 @@
           "#activity+id"
         ]
       }
+    },
+    {
+      "title": "Most-active subsectors",
+      "name": "Most-active subsectors",
+      "description": "",
+      "type": "chart",
+      "ingredients": {
+        "aggregateFunctions": [
+          "distinct-count"
+        ],
+        "aggregateColumns": [
+          "#subsector+name"
+        ],
+        "valueColumns": [
+          "#activity+id"
+        ]
+      }
+    },
+    {
+      "title": "Most-mentioned locations",
+      "name": "Most-mentioned locations",
+      "description": "",
+      "type": "chart",
+      "ingredients": {
+        "aggregateFunctions": [
+          "distinct-count"
+        ],
+        "aggregateColumns": [
+          "#loc+name"
+        ],
+        "valueColumns": [
+          "#activity+id"
+        ]
+      }
     }
   ]
 }

--- a/recipes/iati/recipe.json
+++ b/recipes/iati/recipe.json
@@ -49,7 +49,7 @@
           "distinct-count"
         ],
         "aggregateColumns": [
-          "#sector+name"
+          "#sector"
         ],
         "valueColumns": [
           "#activity+id"


### PR DESCRIPTION
This change supports the Data Partnerships Team -- they need to be able to aggregate tonnage by cargo for shipping in the Black Sea, and none of the current default patterns let them do that. Since an #indicator can be a thing (like type of cargo) as well as a number, this change makes sense.